### PR TITLE
Manager test extended

### DIFF
--- a/__tests__/Manager.test.js
+++ b/__tests__/Manager.test.js
@@ -76,34 +76,34 @@ describe('Manager', () => {
     // Test set 5a: Office Room Number
     it("should set office room number", () => {
         expect(manager.officeNumber).toBe(101);
-        expect(typeof (manager.id)).toBe("number");
+        expect(typeof (manager.officeNumber)).toBe("number");
     })
 
     it("should return office room number", () => {
         expect(manager.getOfficeNumber()).toBe(101);
-        expect(typeof (manager.getId())).toBe("number");
+        expect(typeof (manager.getOfficeNumber())).toBe("number");
     })
 
     // // Test set 5b: Office Room Number - with non-capitalized letters based ID system
-    // it("should set the ID as 'rm 101a'", () => {
-    //     expect(manager.id).toBe("rm 101a");
-    //     expect(typeof (manager.id)).toBe("string");
+    // it("should set the office room number as 'rm 101a'", () => {
+    //     expect(manager.officeNumber).toBe("rm 101a");
+    //     expect(typeof (manager.officeNumber)).toBe("string");
     // })
 
-    // it("should return id", () => {
-    //     expect(manager.getId()).toBe("rm 101a");
-    //     expect(typeof (manager.getId())).toBe("string");
+    // it("should return office room number", () => {
+    //     expect(manager.getOfficeNumber()).toBe("rm 101a");
+    //     expect(typeof (manager.getOfficeNumber())).toBe("string");
     // })
 
     // // Test set 5c: Office Room Number - with capitalized letters based ID system
-    // it("should set the ID as 'RM 101A'", () => {
-    //     expect(manager.id).toBe("RM 101A");
-    //     expect(typeof (manager.id)).toBe("string");
+    // it("should set the office room number as 'RM 101A'", () => {
+    //     expect(manager.officeNumber).toBe("RM 101A");
+    //     expect(typeof (manager.officeNumber)).toBe("string");
     // })
 
-    // it("should return id", () => {
-    //     expect(manager.getId()).toBe("RM 101A");
-    //     expect(typeof (manager.getId())).toBe("string");
+    // it("should return office room number", () => {
+    //     expect(manager.getOfficeNumber()).toBe("RM 101A");
+    //     expect(typeof (manager.getOfficeNumber())).toBe("string");
     // })
 
 });

--- a/__tests__/Manager.test.js
+++ b/__tests__/Manager.test.js
@@ -73,7 +73,7 @@ describe('Manager', () => {
         expect(manager.getRole()).toBe("Manager");
     })
 
-    // Test set 5: Office Room Number
+    // Test set 5a: Office Room Number
     it("should set office room number", () => {
         expect(manager.officeNumber).toBe(101);
         expect(typeof (manager.id)).toBe("number");
@@ -83,4 +83,27 @@ describe('Manager', () => {
         expect(manager.getOfficeNumber()).toBe(101);
         expect(typeof (manager.getId())).toBe("number");
     })
+
+    // // Test set 5b: Office Room Number - with non-capitalized letters based ID system
+    // it("should set the ID as 'rm 101a'", () => {
+    //     expect(manager.id).toBe("rm 101a");
+    //     expect(typeof (manager.id)).toBe("string");
+    // })
+
+    // it("should return id", () => {
+    //     expect(manager.getId()).toBe("rm 101a");
+    //     expect(typeof (manager.getId())).toBe("string");
+    // })
+
+    // // Test set 5c: Office Room Number - with capitalized letters based ID system
+    // it("should set the ID as 'RM 101A'", () => {
+    //     expect(manager.id).toBe("RM 101A");
+    //     expect(typeof (manager.id)).toBe("string");
+    // })
+
+    // it("should return id", () => {
+    //     expect(manager.getId()).toBe("RM 101A");
+    //     expect(typeof (manager.getId())).toBe("string");
+    // })
+
 });


### PR DESCRIPTION
This update corrects a major error that had the office room tests use the ID property for testing. It also extends this test to include alternatives for room labeling systems that have both numbers and letters.